### PR TITLE
Add Intel Gaudi HPU support integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ The quickstart supports two modes of deployments
 - OpenShift Client CLI - [oc](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/cli_tools/openshift-cli-oc#installing-openshift-cli)
 - Helm CLI - helm
 - [huggingface-cli](https://huggingface.co/docs/huggingface_hub/guides/cli) (optional)
-- 1 GPU with 24GB of VRAM for the LLM, refer to the chart below
-- 1 GPU with 24GB of VRAM for the safety/shield model (optional)
+- 1 GPU/HPU with 24GB of VRAM for the LLM, refer to the chart below
+- 1 GPU/HPU with 24GB of VRAM for the safety/shield model (optional)
 - [Hugging Face Token](https://huggingface.co/settings/tokens)
 - Access to [Meta Llama](https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct/) model.
 - Access to [Meta Llama Guard](https://huggingface.co/meta-llama/Llama-Guard-3-8B/) model.
@@ -91,13 +91,13 @@ The quickstart supports two modes of deployments
 
 ### Supported Models
 
-| Function    | Model Name                             | GPU         | AWS
+| Function    | Model Name                             | Hardware    | AWS
 |-------------|----------------------------------------|-------------|-------------
-| Embedding   | `all-MiniLM-L6-v2`                     | CPU or GPU  |
-| Generation  | `meta-llama/Llama-3.2-3B-Instruct`     | L4          | g6.2xlarge
-| Generation  | `meta-llama/Llama-3.1-8B-Instruct`     | L4          | g6.2xlarge
-| Generation  | `meta-llama/Meta-Llama-3-70B-Instruct` | A100 x2     | p4d.24xlarge
-| Safety      | `meta-llama/Llama-Guard-3-8B`          | L4          | g6.2xlarge
+| Embedding   | `all-MiniLM-L6-v2`                     | CPU/GPU/HPU |
+| Generation  | `meta-llama/Llama-3.2-3B-Instruct`     | L4/HPU      | g6.2xlarge
+| Generation  | `meta-llama/Llama-3.1-8B-Instruct`     | L4/HPU      | g6.2xlarge
+| Generation  | `meta-llama/Meta-Llama-3-70B-Instruct` | A100 x2/HPU | p4d.24xlarge
+| Safety      | `meta-llama/Llama-Guard-3-8B`          | L4/HPU      | g6.2xlarge
 
 Note: the 70B model is NOT required for initial testing of this example.  The safety/shield model `Llama-Guard-3-8B` is also optional. 
 
@@ -117,28 +117,29 @@ git clone https://github.com/rh-ai-quickstart/RAG
 oc login --server="<cluster-api-endpoint>" --token="sha256~XYZ"
 ```
 
-3. If the GPU nodes are tainted, find the taint key. You will have to pass in the
-   make command to ensure that the llm pods are deployed on the tainted nodes with GPU.
-   In the example below the key for the taint is `nvidia.com/gpu`
+3. **Hardware Configuration**: Determine what hardware acceleration is available in your cluster and configure accordingly.
 
+   **For NVIDIA GPU nodes**: If GPU nodes are tainted, find the taint key. In the example below the key for the taint is `nvidia.com/gpu`
 
-```bash
-oc get nodes -l nvidia.com/gpu.present=true -o yaml | grep -A 3 taint 
-```
-The output of the command may be something like below
-```
-  taints:
-    - effect: NoSchedule
-      key: nvidia.com/gpu
-      value: "true"
---
-    taints:
-    - effect: NoSchedule
-      key: nvidia.com/gpu
-      value: "true"
-```
+   ```bash
+   oc get nodes -l nvidia.com/gpu.present=true -o yaml | grep -A 3 taint 
+   ```
+   
+   **For Intel Gaudi HPU nodes**: If HPU nodes are tainted, find the taint key. The taint key is typically `habana.ai/gaudi`
 
-You can work with your OpenShift cluster admin team to determine what labels and taints identify GPU-enabled worker nodes.  It is also possible that all your worker nodes have GPUs therefore have no distinguishing taint.
+   ```bash
+   oc get nodes -l habana.ai/gaudi.present=true -o yaml | grep -A 3 taint 
+   ```
+   
+   The output of either command may be something like below:
+   ```
+   taints:
+     - effect: NoSchedule
+       key: nvidia.com/gpu  # or habana.ai/gaudi for HPU
+       value: "true"
+   ```
+
+   You can work with your OpenShift cluster admin team to determine what labels and taints identify GPU-enabled or HPU-enabled worker nodes. It is also possible that all your worker nodes have accelerators therefore have no distinguishing taint.
 
 4. Navigate to Helm deploy directory
 
@@ -173,6 +174,8 @@ Use the taint key from above as the `LLM_TOLERATION` and `SAFETY_TOLERATION`
 
 The namespace will be auto-created
 
+**GPU Deployment Examples (Default):**
+
 To install only the RAG example, no shields, use the following command:
 
 ```bash
@@ -185,10 +188,43 @@ To install both the RAG example as well as the guard model to allow for shields,
 make install NAMESPACE=llama-stack-rag LLM=llama-3-2-3b-instruct LLM_TOLERATION="nvidia.com/gpu" SAFETY=llama-guard-3-8b SAFETY_TOLERATION="nvidia.com/gpu"
 ```
 
-If you have no tainted nodes, perhaps every worker node has a GPU, then you can use a simplified version of the make command
+*Note: `DEVICE=gpu` is the default and can be omitted.*
+
+**Intel Gaudi HPU Deployment Examples:**
+
+To install only the RAG example on Intel Gaudi HPU nodes:
 
 ```bash
+make install NAMESPACE=llama-stack-rag LLM=llama-3-2-3b-instruct LLM_TOLERATION="habana.ai/gaudi" DEVICE=hpu
+```
+
+To install both the RAG example and guard model on Intel Gaudi HPU nodes:
+
+```bash
+make install NAMESPACE=llama-stack-rag LLM=llama-3-2-3b-instruct LLM_TOLERATION="habana.ai/gaudi" SAFETY=llama-guard-3-8b SAFETY_TOLERATION="habana.ai/gaudi" DEVICE=hpu
+```
+
+**CPU Deployment Example:**
+
+To install on CPU nodes only:
+
+```bash
+make install NAMESPACE=llama-stack-rag LLM=llama-3-2-3b-instruct DEVICE=cpu
+```
+
+**Simplified Commands (No Tolerations Needed):**
+
+If you have no tainted nodes (all worker nodes have accelerators), you can use simplified commands:
+
+```bash
+# GPU deployment (default - DEVICE=gpu can be omitted)
 make install NAMESPACE=llama-stack-rag LLM=llama-3-2-3b-instruct SAFETY=llama-guard-3-8b
+
+# HPU deployment  
+make install NAMESPACE=llama-stack-rag LLM=llama-3-2-3b-instruct SAFETY=llama-guard-3-8b DEVICE=hpu
+
+# CPU deployment
+make install NAMESPACE=llama-stack-rag LLM=llama-3-2-3b-instruct SAFETY=llama-guard-3-8b DEVICE=cpu
 ```
 
 When prompted, enter your **[Hugging Face Token]((https://huggingface.co/settings/tokens))**.

--- a/deploy/helm/Makefile
+++ b/deploy/helm/Makefile
@@ -88,7 +88,7 @@ help:
 	@echo "Configuration options (set via environment variables or make arguments):"
 	@echo "  NAMESPACE                - Target namespace (default: llama-stack-rag)"
 	@echo "  HF_TOKEN                 - Hugging Face Token (will prompt if not provided)"
-	@echo "  DEVICE                	  - Deploy models on cpu or gpu (default)"
+	@echo "  DEVICE                	  - Deploy models on cpu, gpu (default), or hpu (Intel Gaudi)"
 	@echo "  {SAFETY,LLM}             - Model id as defined in values (eg. llama-3-2-1b-instruct)"
 	@echo "  {SAFETY,LLM}_URL         - Model URL"
 	@echo "  {SAFETY,LLM}_API_TOKEN   - Model API token for remote models"

--- a/deploy/helm/rag/values.yaml
+++ b/deploy/helm/rag/values.yaml
@@ -35,8 +35,13 @@ volumeMounts:
     name: dot-streamlit
 
 # Common model values for llm-service and llama-stack
-# See format in https://github.com/RHEcosystemAppEng/ai-architecture-charts/blob/main/helm/llm-service/values.yaml
+# See format in https://github.com/rh-ai-quickstart/ai-architecture-charts/blob/main/llm-service/helm/values.yaml
 # For e.g., to add a new model add the following block and it will append to the list of models defined in the llm-service
+# 
+# Device Support:
+# - Use DEVICE=cpu for CPU-only deployment
+# - Use DEVICE=gpu for NVIDIA GPU deployment (default)
+# - Use DEVICE=hpu for Intel Gaudi HPU deployment (requires Intel Gaudi drivers and setup)
 
 # global:
 #   models:
@@ -63,27 +68,32 @@ volumeMounts:
 #       - llama3_json
 #       - --max-model-len
 #       - "30444"
+#     # Example HPU (Intel Gaudi) configuration:
+#     llama-3-2-3b-instruct:
+#       id: meta-llama/Llama-3.2-3B-Instruct
+#       enabled: true
+#       device: "hpu"
+#       accelerators: "1" # Can be omitted, defaults to 1
+#       args:
+#       - --max-model-len
+#       - "14336"
+#       - --max-num-seqs
+#       - "32"
 #     llama-guard-3-8b:
 #       id: meta-llama/Llama-Guard-3-8B
 #       enabled: true
 #       registerShield: true
-#       tolerations:
-#       - key: "nvidia.com/gpu"
-#         operator: Exists
-#         effect: NoSchedule      
+#       device: "hpu"    
 #       args:
 #       - --max-model-len
 #       - "14336"
+#       - --max-num-seqs
+#       - "32"
 #     granite-vision-3-2-2b:
 #       id: ibm-granite/granite-vision-3.2-2b
-#       enabled: true      
-#       resources:
-#         limits:
-#           nvidia.com/gpu: "1"
-#       tolerations:
-#       - key: "nvidia.com/gpu"
-#         operator: Exists
-#         effect: NoSchedule
+#       enabled: true
+#       device: "gpu"  # Options: "cpu", "gpu", "hpu"
+#       accelerators: "1"
 #       args:
 #       - --tensor-parallel-size
 #       - "1"


### PR DESCRIPTION
Please merge once the [llm-service](https://github.com/rh-ai-quickstart/RAG/blob/main/deploy/helm/rag/Chart.yaml#L15) has been updated to include [PR #63](https://github.com/rh-ai-quickstart/ai-architecture-charts/pull/63/files).

- Integrate DEVICE=hpu parameter from [ai-architecture-charts](https://github.com/rh-ai-quickstart/ai-architecture-charts/tree/main/llm-service#installation-with-hpu-intel-gaudi-support)
- Update Makefile to include HPU option alongside CPU and GPU
- Update documentation